### PR TITLE
Add proper device and state classes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,6 @@
     "python.linting.pylintEnabled": false,
     "python.formatting.provider": "black",
     "python.testing.pytestEnabled": true,
-    "python.testing.pytestArgs": ["--hypothesis-show-statistics"],
     "python.analysis.diagnosticMode": "workspace",
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/py_hpsu_monitor/elster_protocol/register_definitions.toml
+++ b/py_hpsu_monitor/elster_protocol/register_definitions.toml
@@ -118,11 +118,10 @@
 
 [[register_definitions]]
   elster_index = 0x001C
-  factor = 0.001
   kind = "number"
   name = "wasserdruck"
   owner_id = 0x180
-  unit = "bar"
+  unit = "mbar"
 
 [[register_definitions]]
   elster_index = 0xC0F7

--- a/py_hpsu_monitor/workers/elster_register_mqtt_logger.py
+++ b/py_hpsu_monitor/workers/elster_register_mqtt_logger.py
@@ -133,6 +133,7 @@ device_class_by_unit = {
     "kW": "power",
     "Wh": "energy",
     "kWh": "energy",
+    "mbar": "pressure",
 }
 
 state_class_by_unit = {
@@ -141,4 +142,5 @@ state_class_by_unit = {
     "kW": "measurement",
     "Wh": "total_increasing",
     "kWh": "total_increasing",
+    "mbar": "measurement",
 }

--- a/py_hpsu_monitor/workers/elster_register_mqtt_logger.py
+++ b/py_hpsu_monitor/workers/elster_register_mqtt_logger.py
@@ -104,6 +104,7 @@ def get_device_class(register_definition: RegisterDefinition):
         and register_definition.unit
     ):
         device_class = device_class_by_unit.get(register_definition.unit, None)
+        state_class = state_class_by_unit.get(register_definition.unit, None)
 
         return {
             "unit_of_measurement": register_definition.unit,
@@ -114,9 +115,30 @@ def get_device_class(register_definition: RegisterDefinition):
                 if device_class
                 else {}
             ),
+            **(
+                {
+                    "state_class": state_class,
+                }
+                if state_class
+                else {}
+            ),
         }
 
     return {}
 
 
-device_class_by_unit = {"°C": "temperature", "W": "power", "kW": "power"}
+device_class_by_unit = {
+    "°C": "temperature",
+    "W": "power",
+    "kW": "power",
+    "Wh": "energy",
+    "kWh": "energy",
+}
+
+state_class_by_unit = {
+    "°C": "measurement",
+    "W": "measurement",
+    "kW": "measurement",
+    "Wh": "total_increasing",
+    "kWh": "total_increasing",
+}

--- a/py_hpsu_monitor/workers/tests/test_elster_register_mqtt_logger.py
+++ b/py_hpsu_monitor/workers/tests/test_elster_register_mqtt_logger.py
@@ -66,6 +66,7 @@ async def test_mqtt_logger_publishes_autodiscovery(event_loop):
                         "unique_id": "test-device-id-test-number-register",
                         "unit_of_measurement": "°C",
                         "device_class": "temperature",
+                        "state_class": "measurement",
                     }
                 ),
                 retain=True,


### PR DESCRIPTION
## :memo: Summary

This improves the device classes to include energy and pressure. It also adds state classes for the same units. To align the with the HA pressure unit this also changes the pressure unit to `mbar` instead of `bar`.